### PR TITLE
[kinesis] Disabled testGetStreamNamesWithPagination on CI because of cost

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandlerIntegrationTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandlerIntegrationTest.java
@@ -112,7 +112,7 @@ public class KinesisConnectionHandlerIntegrationTest {
         "Expected to find test stream " + _testStreamName + " in list of streams: " + streams);
   }
 
-  @Test(dependsOnMethods = "testGetStreamNames")
+  @Test(dependsOnMethods = "testGetStreamNames", enabled = false)
   public void testGetStreamNamesWithPagination() {
     // Create additional test streams to test pagination
     String[] additionalStreams = new String[3];


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
